### PR TITLE
Dependencyupdate

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -8,9 +8,11 @@ environment:
 
 dependencies:
   collection: ^1.17.0
-  intl: ^0.19.0
-  format: ^1.2.0
+  intl: ^0.20.2
+  format: ^1.6.0
 
 dev_dependencies:
-  lints: ^4.0.0
+  lints: ^6.0.0
   test: ^1.21.0
+
+  

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -8,11 +8,11 @@ environment:
 
 dependencies:
   collection: ^1.17.0
-  intl: ^0.20.2
-  format: ^1.6.0
+  intl: '>=0.19.0 <1.0.0'
+  format: ^1.2.0
 
 dev_dependencies:
-  lints: ^6.0.0
+  lints: ^4.0.0
   test: ^1.21.0
 
   


### PR DESCRIPTION
Current intl version is 0.20.x which is not permitted with our version `intl: ^0.19.0`. Getting conflicts with other libs. 

For null major versions, the ^ does not  include minor version updates, only for major versions greater 0 minor updates are permitted. See https://dart.dev/tools/pub/dependencies#caret-syntax

intl  0.20.2 works, so we should allow it. 


